### PR TITLE
Added git-tag based release tasks to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build-output
 .ssh-remote
 *~
 ocf-scheduler-cf-plugin
+builds

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# This is how we want to name the binary output
+BINARY=ocf-scheduler-cf-plugin
+VERSION=`./scripts/genver`
+PACKAGE="github.com/starkandwayne/ocf-scheduler-cf-plugin"
+TARGET="builds/${BINARY}-${VERSION}"
+PREFIX="${TARGET}/${BINARY}-${VERSION}"
+
 GO_LDFLAGS := -ldflags="-X main.Version=$(VERSION)"
 
 REMOTE_HOST := $(shell cat .ssh-remote)
@@ -5,6 +12,24 @@ REMOTE_FOLDER := ~/programs/ocf-scheduler/ocf-scheduler-cf-plugin
 
 build:
 	go build $(GO_LDFLAGS) .
+
+release: distclean distbuild linux darwin
+
+distbuild:
+	mkdir -p ${TARGET}
+
+distclean:
+	rm -rf ${TARGET}
+
+linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${GO_LDFLAGS} -o ${TARGET}/${BINARY}-linux-amd64 ${PACKAGE}
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${GO_LDFLAGS} -o ${TARGET}/${BINARY}-linux-arm64 ${PACKAGE}
+
+darwin:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build ${GO_LDFLAGS} -o ${TARGET}/${BINARY}-macos-amd64 ${PACKAGE}
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ${GO_LDFLAGS} -o ${TARGET}/${BINARY}-macos-arm64 ${PACKAGE}
+	
+
 
 docker-build:
 	docker build -t ocf-scheduler-cf-plugin .

--- a/scripts/genver
+++ b/scripts/genver
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ver=$(git describe --tags 2>/dev/null | cut -d '-' -f 1 | head -n 1)
+
+if [ -z "${ver}" ]
+then
+  echo "v0.0.0"
+else
+  echo "${ver}"
+fi


### PR DESCRIPTION
This adds a `make release` target that does a distclean, a
distbuild, and generates linux and macos binaries in
builds/ocf-scheduler-cf-plugin-vX.Y.Z, where the version is
based on the most recent git tag.

This is really meant to only be used when we cut a release to the
main branch, and it should also be done from the main branch most
likely.